### PR TITLE
chore(netjet): Name anonymous middleware function

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ module.exports = function netjet(options) {
 
   var cache = new LRU(options.cache);
 
-  return function (req, res, next) {
+  return function netjetMiddleware(req, res, next) {
     function appendHeader(field, value) {
       var prev = res.getHeader(field);
 


### PR DESCRIPTION
I've been working on refactoring Ghost's middleware setup & as a result I'm also working on a little tool for inspecting express middleware.

The middleware function provided by this module is currently anonymous, which makes debugging & inspection a little bit tricky. Adding a name shouldn't have any impact other than making it easier to debug and inspect this middleware.

I've run the tests & tried to follow your commit message format, but happy to amend to your liking.