### PR TITLE
Don't attempt to preload inline images

### DIFF
--- a/posthtml-preload.js
+++ b/posthtml-preload.js
@@ -45,6 +45,8 @@ module.exports = function (options, foundEntries) {
             foundEntries.push([node.attrs.href, 'base']);
             break;
           case 'img':
+            // Skip inline images
+            if (node.attrs.src.indexOf('data:') === 0) { break; }
             foundEntries.push([node.attrs.src, 'image']);
             break;
           case 'script':

--- a/posthtml-preload.js
+++ b/posthtml-preload.js
@@ -45,9 +45,10 @@ module.exports = function (options, foundEntries) {
             foundEntries.push([node.attrs.href, 'base']);
             break;
           case 'img':
-            // Skip inline images
-            if (node.attrs.src.indexOf('data:') === 0) { break; }
-            foundEntries.push([node.attrs.src, 'image']);
+            // Ensure we're not preloading an inline image
+            if (node.attrs.src.indexOf('data:') !== 0) {            
+              foundEntries.push([node.attrs.src, 'image']);
+            }
             break;
           case 'script':
             foundEntries.push([node.attrs.src, 'script']);

--- a/posthtml-preload.js
+++ b/posthtml-preload.js
@@ -46,7 +46,7 @@ module.exports = function (options, foundEntries) {
             break;
           case 'img':
             // Ensure we're not preloading an inline image
-            if (node.attrs.src.indexOf('data:') !== 0) {            
+            if (node.attrs.src.indexOf('data:') !== 0) {
               foundEntries.push([node.attrs.src, 'image']);
             }
             break;


### PR DESCRIPTION
Because it's pointless (no performance upside possible) and can lead to large `link` headers which will exceed nginx's max header / buffer size (causing the user's request to fail with a `502 Bad Gateway`)

Should mostly fix #23