### PR TITLE
Add optional directives for Link headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ express()
 
   Object passed straight to [`lru-cache`][lru-cache]. It is highly recommended to set `cache.max` to an integer.
 
+* **directives**: `Array<String>`
+
+  List of custom directives that should be added to the Preload Link headers.
+
 ## License
 
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](https://www.tldrlegal.com/l/mit) see `LICENSE.md`.

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ express()
 
   Object passed straight to [`lru-cache`][lru-cache]. It is highly recommended to set `cache.max` to an integer.
 
-* **directives**: `Array<String>`
+* **attributes**: `Array<String>`
 
-  List of custom directives that should be added to the Preload Link headers.
+  List of custom attributes that should be added to the Preload Link headers.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -20,9 +20,11 @@ module.exports = function netjet(options) {
     scripts: true,
     styles: true,
     cache: {},
+    directives: [],
   });
 
   var cache = new LRU(options.cache);
+  var directives = [''].concat(options.directives).join('; ');
 
   return function netjetMiddleware(req, res, next) {
     function appendHeader(field, value) {
@@ -60,7 +62,7 @@ module.exports = function netjet(options) {
               (addBaseHref ? baseTag[0] : '') +
               encodeRFC5987(unescape(url)) +
               '>; rel=preload; as=' +
-              asType
+              asType + directives
           );
         });
     }

--- a/index.js
+++ b/index.js
@@ -20,11 +20,11 @@ module.exports = function netjet(options) {
     scripts: true,
     styles: true,
     cache: {},
-    directives: [],
+    attributes: [],
   });
 
   var cache = new LRU(options.cache);
-  var directives = [''].concat(options.directives).join('; ');
+  var attributes = [''].concat(options.attributes).join('; ');
 
   return function netjetMiddleware(req, res, next) {
     function appendHeader(field, value) {
@@ -62,7 +62,8 @@ module.exports = function netjet(options) {
               (addBaseHref ? baseTag[0] : '') +
               encodeRFC5987(unescape(url)) +
               '>; rel=preload; as=' +
-              asType + directives
+              asType +
+              attributes
           );
         });
     }

--- a/test/preload.js
+++ b/test/preload.js
@@ -322,10 +322,10 @@ describe('preload', function() {
     });
   });
 
-  describe('directives', function() {
-    it('should add a custom directive', function(done) {
+  describe('attributes', function() {
+    it('should add a custom attribute', function(done) {
       var server = createServer({
-        directives: ['nopush'],
+        attributes: ['nopush'],
       });
 
       request(server)
@@ -335,9 +335,9 @@ describe('preload', function() {
         .expect(404, done);
     });
 
-    it('should add the custom directives', function(done) {
+    it('should add the custom attributes', function(done) {
       var server = createServer({
-        directives: ['nopush', 'x-http2-push-only'],
+        attributes: ['nopush', 'x-http2-push-only'],
       });
 
       request(server)

--- a/test/preload.js
+++ b/test/preload.js
@@ -321,6 +321,35 @@ describe('preload', function() {
         });
     });
   });
+
+  describe('directives', function() {
+    it('should add a custom directive', function(done) {
+      var server = createServer({
+        directives: ['nopush'],
+      });
+
+      request(server)
+        .get('/404')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect('Link', '</images/droids.png>; rel=preload; as=image; nopush')
+        .expect(404, done);
+    });
+
+    it('should add the custom directives', function(done) {
+      var server = createServer({
+        directives: ['nopush', 'x-http2-push-only'],
+      });
+
+      request(server)
+        .get('/404')
+        .expect('Content-Type', 'text/html; charset=utf-8')
+        .expect(
+          'Link',
+          '</images/droids.png>; rel=preload; as=image; nopush; x-http2-push-only'
+        )
+        .expect(404, done);
+    });
+  });
 });
 
 function createServer(options) {


### PR DESCRIPTION
The W3C spec defines some directives such as `nopush`: https://www.w3.org/TR/preload/#server-push-http-2

And some CDNs (such as [Fastly](https://docs.fastly.com/guides/performance-tuning/http2-server-push)) supports it to control the behaviour of the CDN (they also support other directives such as `x-http2-push-only`).

This PR adds an option `directives` to define these directives:

```js
express()
  .use(netjet({
    directives: ['nopush']
  }))
  .use(express.static(root))
  .listen(1337);
```