### PR TITLE
feat(matchers): ignore scripts with nomodule

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,10 +51,16 @@ module.exports = function netjet(options) {
         })
         .forEach(function(entry) {
           var url = entry[0];
-          var asType = entry[1];
+          var crossOrigin = entry[1];
+          var asType = entry[2];
           var addBaseHref =
             baseTag !== undefined &&
             !new RegExp('^([a-z]+://|/)', 'i').test(url);
+
+          var crossOriginString = '';
+          if (crossOrigin) {
+            crossOriginString = '; crossorigin=' + crossOrigin;
+          }
 
           appendHeader(
             'Link',
@@ -63,6 +69,7 @@ module.exports = function netjet(options) {
               encodeRFC5987(unescape(url)) +
               '>; rel=preload; as=' +
               asType +
+              crossOriginString + 
               attributes
           );
         });

--- a/posthtml-preload.js
+++ b/posthtml-preload.js
@@ -48,14 +48,14 @@ module.exports = function(options, foundEntries) {
           case 'img':
             // Ensure we're not preloading an inline image
             if (node.attrs.src.indexOf('data:') !== 0) {
-              foundEntries.push([node.attrs.src, 'image']);
+              foundEntries.push([node.attrs.src, node.attrs.crossorigin, 'image']);
             }
             break;
           case 'script':
-            foundEntries.push([node.attrs.src, 'script']);
+            foundEntries.push([node.attrs.src, node.attrs.crossorigin, 'script']);
             break;
           case 'link':
-            foundEntries.push([node.attrs.href, 'style']);
+            foundEntries.push([node.attrs.href, node.attrs.crossorigin, 'style']);
             break;
           // no default
         }

--- a/posthtml-preload.js
+++ b/posthtml-preload.js
@@ -25,6 +25,7 @@ module.exports = function(options, foundEntries) {
         tag: 'script',
         attrs: {
           src: true,
+          nomodule: false,
         },
       });
     }

--- a/test/preload.js
+++ b/test/preload.js
@@ -128,6 +128,14 @@ describe('preload', function() {
           .expect(200, done);
       });
 
+      it('should include crossorigin property on scripts', function(done) {
+        request(this.server)
+          .get('/blog/module-script')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect('Link', '</jquery.min.js>; rel=preload; as=script; crossorigin=anonymous')
+          .expect(200, done);
+      });
+
       it('should create Link header for multiple scripts', function(done) {
         request(this.server)
           .get('/blog/multi-script')
@@ -313,7 +321,7 @@ describe('preload', function() {
         })
         .then(function() {
           return td.verify(
-            disposer('1', [['/images/etag1.png?count=1', 'image']])
+            disposer('1', [['/images/etag1.png?count=1', undefined, 'image']])
           );
         })
         .then(function() {
@@ -437,6 +445,15 @@ function createServer(options) {
       res.statusCode = 200;
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.write('<script src="/jquery.min.js" nomodule defer></script>');
+      res.end();
+    },
+  });
+
+  router.route('/blog/module-script', {
+    GET: function(req, res) {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.write('<script src="/jquery.min.js" type="module" crossorigin="anonymous" defer></script>');
       res.end();
     },
   });

--- a/test/preload.js
+++ b/test/preload.js
@@ -121,7 +121,14 @@ describe('preload', function() {
           .expect(200, done);
       });
 
-      it('should create Link header for mutliple scripts', function(done) {
+      it('should ignore nomodule scripts', function(done) {
+        request(this.server)
+          .get('/blog/nomodule-script')
+          .expect('Content-Type', 'text/html; charset=utf-8')
+          .expect(200, done);
+      });
+
+      it('should create Link header for multiple scripts', function(done) {
         request(this.server)
           .get('/blog/multi-script')
           .expect('Content-Type', 'text/html; charset=utf-8')
@@ -421,6 +428,15 @@ function createServer(options) {
       res.statusCode = 200;
       res.setHeader('Content-Type', 'text/html; charset=utf-8');
       res.write('<script src="/jquery.min.js"></script>');
+      res.end();
+    },
+  });
+
+  router.route('/blog/nomodule-script', {
+    GET: function(req, res) {
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.write('<script src="/jquery.min.js" nomodule defer></script>');
       res.end();
     },
   });


### PR DESCRIPTION
Addresses: https://github.com/cloudflare/netjet/issues/37

This PR will improve perf for 86.6% of requests globally. We could go one step further and check user-agent to enable/disable the feature but this is already better:
<img width="1281" alt="Screenshot 2019-10-17 at 12 10 35" src="https://user-images.githubusercontent.com/1162531/66999941-2de30b80-f0d7-11e9-99c1-f4aba5580ffd.png">


One thing I wasn't sure about is how to test against a header NOT being there. It fails with the assertion but the only thing I could do was just remove that assertion. Tried a couple of:

```
.expect('Link', null)
.expect('Link', undefined)
.expect('Link', false)
```